### PR TITLE
Use `enable_custom_integrations` fixture in tests

### DIFF
--- a/tests/test__init.py
+++ b/tests/test__init.py
@@ -24,6 +24,7 @@ from tests.const import MOCK_CONFIG
 
 @pytest.fixture(autouse=True)
 def auto_enable_custom_integrations(enable_custom_integrations):
+    """Use enable_custom_integrations in this module."""
     yield
 
 

--- a/tests/test__init.py
+++ b/tests/test__init.py
@@ -22,6 +22,10 @@ from custom_components.jq300 import (
 from tests.const import MOCK_CONFIG
 
 
+@pytest.fixture(autouse=True)
+def auto_enable_custom_integrations(enable_custom_integrations):
+    yield
+
 async def test_async_setup(hass: HomeAssistant):
     """Test a successful setup component."""
     with assert_setup_component(5, DOMAIN):

--- a/tests/test__init.py
+++ b/tests/test__init.py
@@ -26,6 +26,7 @@ from tests.const import MOCK_CONFIG
 def auto_enable_custom_integrations(enable_custom_integrations):
     yield
 
+
 async def test_async_setup(hass: HomeAssistant):
     """Test a successful setup component."""
     with assert_setup_component(5, DOMAIN):

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -9,6 +9,11 @@ from custom_components.jq300 import DOMAIN
 from custom_components.jq300.config_flow import Jq300FlowHandler
 
 
+@pytest.fixture(autouse=True)
+def auto_enable_custom_integrations(enable_custom_integrations):
+    yield
+
+
 async def test_async_step_import(hass: HomeAssistant):
     """Test a successful config flow import."""
     config = {"some": "data"}

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -2,6 +2,7 @@
 
 from unittest.mock import patch
 
+import pytest
 from homeassistant import config_entries, data_entry_flow
 from homeassistant.core import HomeAssistant
 
@@ -11,6 +12,7 @@ from custom_components.jq300.config_flow import Jq300FlowHandler
 
 @pytest.fixture(autouse=True)
 def auto_enable_custom_integrations(enable_custom_integrations):
+    """Use enable_custom_integrations in this module."""
     yield
 
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
homeassistant requires using this fixture in tests since 2021.6.x.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality to an this integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] The code has been formatted using Black (`black --fast custom_components`)

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated to README.md

<!--
  Thank you for contributing <3
-->
